### PR TITLE
(tk 47)(enh)code refacto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
 
-      # 4. Check imports with isort (mode check only)
+      # 4. Check code formatting with black
+      - name: Run black check
+        run: black --check .
+
+      # 5. Check imports with isort (mode check only)
       - name: Run isort check
         run: isort --check-only --diff .
 
-      # 5. Check code style with flake8
+      # 6. Check code style with flake8
       - name: Run flake8
         run: flake8 .
 
-      # 6. Run tests with coverage
+      # 7. Run tests with coverage
       - name: Run tests with pytest and coverage
         run: |
           pytest --cov=. --cov-report=html --cov-report=term-missing
 
-      # 7. Save coverage report like artefact
+      # 8. Save coverage report like artefact
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       # 4. Check code formatting with black
       - name: Run black check
-        run: black --check .
+        run: black --check ./gardeniq
 
       # 5. Check imports with isort (mode check only)
       - name: Run isort check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language: system
         types: [python]
         require_serial: true
-        args: [--force-exclude, gardeniq]
+        args: [gardeniq, --force-exclude, ^.*/migrations/.*$]
 
       - id: check-json
         name: Check Json

--- a/gardeniq/base/admin.py
+++ b/gardeniq/base/admin.py
@@ -1,3 +1,14 @@
-# from django.contrib import admin
+from django.contrib import admin
 
-# Register your models here.
+from gardeniq.base.models.status import Status
+
+
+@admin.register(Status)
+class StatusAdmin(admin.ModelAdmin):
+    """Admin interface for the Status model."""
+
+    list_display = ("id", "name", "tag", "color", "description")
+    search_fields = ("name", "tag")
+    list_filter = ("color",)
+    # For ordering fields in admin create and update forms.
+    fields = list(filter(lambda f: f != "id", list_display))

--- a/gardeniq/base/api_urls.py
+++ b/gardeniq/base/api_urls.py
@@ -9,7 +9,6 @@ router.register(
     r"status",
     StatusAPIModelView,
     basename="status",
-
 )
 
 urlpatterns = router.urls

--- a/gardeniq/base/fixtures/seeders/base.py
+++ b/gardeniq/base/fixtures/seeders/base.py
@@ -26,32 +26,25 @@ class BaseSeeder:
     ) -> None:
         """Check if class attributs is set by children."""
         assert hasattr(self, "model"), (
-            "Error missing `model` attribut to `BaseSeeder` class for %s"
-            % self.__class__.__name__
+            "Error missing `model` attribut to `BaseSeeder` class for %s" % self.__class__.__name__
         )
         assert issubclass(self.model, Model), (
-            "Error `model` attribut must be a subclass of `Model` for %s"
-            % self.__class__.__name__
+            "Error `model` attribut must be a subclass of `Model` for %s" % self.__class__.__name__
         )
         assert hasattr(self, "serializer"), (
-            "Error missing `serializer` attribut to `BaseSeeder` class for %s"
-            % self.__class__.__name__
+            "Error missing `serializer` attribut to `BaseSeeder` class for %s" % self.__class__.__name__
         )
         assert issubclass(self.serializer, Serializer), (
-            "Error `serializer` attribut must be a subclass of `Serializer` for %s"
-            % self.__class__.__name__
+            "Error `serializer` attribut must be a subclass of `Serializer` for %s" % self.__class__.__name__
         )
         assert hasattr(self, "filename"), (
-            "Error missing `filename` attribut to `BaseSeeder` class for %s"
-            % self.__class__.__name__
+            "Error missing `filename` attribut to `BaseSeeder` class for %s" % self.__class__.__name__
         )
         assert hasattr(self, "root_dir_source"), (
-            "Error missing `root_dir_source` attribut to `BaseSeeder` class for %s"
-            % self.__class__.__name__
+            "Error missing `root_dir_source` attribut to `BaseSeeder` class for %s" % self.__class__.__name__
         )
         assert hasattr(self, "search_field_name"), (
-            "Error missing `search_field_name` attribut to `BaseSeeder` class for %s"
-            % self.__class__.__name__
+            "Error missing `search_field_name` attribut to `BaseSeeder` class for %s" % self.__class__.__name__
         )
 
         self.success_logger = success_logger

--- a/gardeniq/base/models/status.py
+++ b/gardeniq/base/models/status.py
@@ -10,10 +10,15 @@ class Status(NameMixinModel, OptionalDescriptionMixinModel):
       - `name`
       - `description`:optional
     """
+
     DEFAULT_COLOR = "#A2A2A2"
 
     tag = models.SlugField(verbose_name="tag", help_text="A tag of this status. (Like category).")
     color = models.CharField(max_length=7, default=DEFAULT_COLOR, verbose_name="color")
+
+    class Meta:
+        verbose_name = "status"
+        verbose_name_plural = "statuses"
 
     def __str__(self) -> str:
         return f"Status `{self.name}` : {self.tag}"

--- a/gardeniq/base/routers.py
+++ b/gardeniq/base/routers.py
@@ -12,6 +12,7 @@ class ToggleObjectRouter(DefaultRouter):
 
     These routes are intended for toggling the enabled/disabled state of an object via custom viewset actions.
     """
+
     routes = [
         Route(
             url=r"^{prefix}/{lookup}/enable{trailing_slash}$",

--- a/gardeniq/base/serializers/bases.py
+++ b/gardeniq/base/serializers/bases.py
@@ -14,8 +14,7 @@ class BaseSerializer(PKMixinSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         assert hasattr(self.Meta, "model"), (
-            "Error missing `model` attribut to `Meta` class for %s"
-            % self.__class__.__name__
+            "Error missing `model` attribut to `Meta` class for %s" % self.__class__.__name__
         )
 
     def create(self, validated_data: Dict):
@@ -44,14 +43,10 @@ class ReadOnlySerializer(serializers.Serializer):
         """
         Raises NotImplementedError because this read-only serializer does not create objects.
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} is read-only and cannot create objects."
-        )
+        raise NotImplementedError(f"{self.__class__.__name__} is read-only and cannot create objects.")
 
     def update(self, instance, validated_data):
         """
         Raises NotImplementedError because this read-only serializer does not update objects.
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} is read-only and cannot update objects."
-        )
+        raise NotImplementedError(f"{self.__class__.__name__} is read-only and cannot update objects.")

--- a/gardeniq/base/serializers/mixins.py
+++ b/gardeniq/base/serializers/mixins.py
@@ -32,8 +32,7 @@ class AutocompleteSlugMixinSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         assert hasattr(self.Meta, "prepopulated_slug_with"), (
-            "Error missing `prepopulated_slug_with` attribut to `Meta` class for %s"
-            % self.__class__.__name__
+            "Error missing `prepopulated_slug_with` attribut to `Meta` class for %s" % self.__class__.__name__
         )
 
     def validate(self, data):

--- a/gardeniq/base/serializers/status.py
+++ b/gardeniq/base/serializers/status.py
@@ -8,7 +8,7 @@ from gardeniq.base.serializers import NameMixinSerializer
 from gardeniq.base.serializers import OptionalDescriptionMixinSerializer
 from gardeniq.base.serializers import ReadOnlySerializer
 
-color_regex = re.compile(r'^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')
+color_regex = re.compile(r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
 
 
 class StatusSerializer(
@@ -17,7 +17,12 @@ class StatusSerializer(
     OptionalDescriptionMixinSerializer,
 ):
     tag = serializers.SlugField()
-    color = serializers.RegexField(color_regex, max_length=7, min_length=3, default=Status.DEFAULT_COLOR,)
+    color = serializers.RegexField(
+        color_regex,
+        max_length=7,
+        min_length=3,
+        default=Status.DEFAULT_COLOR,
+    )
 
     class Meta:
         model = Status
@@ -37,4 +42,5 @@ class StatusReadOnlySerializer(ReadOnlySerializer, StatusSerializer):
     This serializer is intended for use cases where Status data should be exposed
     in a read-only format, preventing any modifications through the API.
     """
+
     pass

--- a/gardeniq/base/tests/test_commands.py
+++ b/gardeniq/base/tests/test_commands.py
@@ -30,7 +30,7 @@ class TestCommands:
         "app_name, model_obj",
         [
             ("orderlg", [Argument, Order]),
-            ("base", [Status])
+            ("base", [Status]),
         ],
     )
     def test_seed_with_app_name(self, app_name, model_obj):

--- a/gardeniq/base/tests/tests_models/test_status.py
+++ b/gardeniq/base/tests/tests_models/test_status.py
@@ -1,0 +1,251 @@
+import pytest
+
+from gardeniq.base.models.status import Status
+
+
+@pytest.fixture
+def status_data():
+    """Fixture providing basic data to create a Status."""
+    return {
+        "name": "In progress",
+        "tag": "in-progress",
+        "color": "#3498db",
+        "description": "Task in progress",
+    }
+
+
+@pytest.fixture
+def status_without_description():
+    """Fixture providing data without description."""
+    return {
+        "name": "To do",
+        "tag": "todo",
+        "color": "#95a5a6",
+    }
+
+
+@pytest.fixture
+def status_with_default_color():
+    """Fixture providing data without custom color."""
+    return {
+        "name": "New",
+        "tag": "new",
+    }
+
+
+@pytest.mark.django_db
+class TestStatusCreation:
+    """Tests for Status model creation."""
+
+    def test_create_status_with_all_fields(self, status_data):
+        """
+        GIVEN: complete data for a Status
+        WHEN: creating a Status with all fields
+        THEN: the Status is created with correct values
+        """
+        # GIVEN - data is provided by the status_data fixture
+
+        # WHEN
+        status = Status.objects.create(**status_data)
+
+        # THEN
+        assert status.pk is not None
+        assert status.name == status_data["name"]
+        assert status.tag == status_data["tag"]
+        assert status.color == status_data["color"]
+        assert status.description == status_data["description"]
+
+    def test_create_status_without_description(self, status_without_description):
+        """
+        GIVEN: data without the description field
+        WHEN: creating a Status without description
+        THEN: the Status is created with an empty description
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        status = Status.objects.create(**status_without_description)
+
+        # THEN
+        assert status.pk is not None
+        assert status.name == status_without_description["name"]
+        assert status.tag == status_without_description["tag"]
+        assert status.description == ""
+
+    def test_create_status_with_default_color(self, status_with_default_color):
+        """
+        GIVEN: data without the color field
+        WHEN: creating a Status without specifying a color
+        THEN: the Status is created with the default color
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        status = Status.objects.create(**status_with_default_color)
+
+        # THEN
+        assert status.pk is not None
+        assert status.color == Status.DEFAULT_COLOR
+        assert status.color == "#A2A2A2"
+
+
+@pytest.mark.django_db
+class TestStatusStringRepresentation:
+    """Tests for Status model string representation."""
+
+    def test_str_method_returns_correct_format(self, status_data):
+        """
+        GIVEN: a created Status
+        WHEN: calling the __str__ method
+        THEN: it returns the format "Status `{name}` : {tag}"
+        """
+        # GIVEN
+        status = Status.objects.create(**status_data)
+
+        # WHEN
+        result = str(status)
+
+        # THEN
+        expected = f"Status `{status_data['name']}` : {status_data['tag']}"
+        assert result == expected
+
+
+@pytest.mark.django_db
+class TestStatusFields:
+    """Tests for Status model fields and constraints."""
+
+    def test_name_field_max_length(self):
+        """
+        GIVEN: a name of 255 characters (maximum length)
+        WHEN: creating a Status with this name
+        THEN: the Status is created without error
+        """
+        # GIVEN
+        long_name = "A" * 255
+
+        # WHEN
+        status = Status.objects.create(
+            name=long_name,
+            tag="test-long-name",
+        )
+
+        # THEN
+        assert status.name == long_name
+        assert len(status.name) == 255
+
+    def test_color_field_max_length(self):
+        """
+        GIVEN: a valid hexadecimal color of 7 characters
+        WHEN: creating a Status with this color
+        THEN: the Status is created with the correct color
+        """
+        # GIVEN
+        hex_color = "#FF5733"
+
+        # WHEN
+        status = Status.objects.create(
+            name="Test color",
+            tag="test-color",
+            color=hex_color,
+        )
+
+        # THEN
+        assert status.color == hex_color
+        assert len(status.color) == 7
+
+    def test_tag_is_slug_field(self):
+        """
+        GIVEN: a valid tag in slug format
+        WHEN: creating a Status with this tag
+        THEN: the Status is created with the correct tag
+        """
+        # GIVEN
+        slug_tag = "pending-validation"
+
+        # WHEN
+        status = Status.objects.create(
+            name="Pending validation",
+            tag=slug_tag,
+        )
+
+        # THEN
+        assert status.tag == slug_tag
+
+    def test_description_can_be_blank(self):
+        """
+        GIVEN: data without description
+        WHEN: creating and saving a Status
+        THEN: the description field is empty and accepts blank=True
+        """
+        # GIVEN / WHEN
+        status = Status.objects.create(
+            name="Test",
+            tag="test",
+        )
+
+        # THEN
+        assert status.description == ""
+        # Verify that the field accepts blank
+        status.full_clean()  # Should not raise an exception
+
+
+@pytest.mark.django_db
+class TestStatusUpdate:
+    """Tests for Status model update operations."""
+
+    def test_update_status_color(self, status_data):
+        """
+        GIVEN: an existing Status
+        WHEN: updating its color
+        THEN: the color is modified correctly
+        """
+        # GIVEN
+        status = Status.objects.create(**status_data)
+        new_color = "#FF0000"
+
+        # WHEN
+        status.color = new_color
+        status.save()
+
+        # THEN
+        updated_status = Status.objects.get(pk=status.pk)
+        assert updated_status.color == new_color
+
+    def test_update_status_description(self, status_data):
+        """
+        GIVEN: an existing Status with a description
+        WHEN: updating its description
+        THEN: the description is modified correctly
+        """
+        # GIVEN
+        status = Status.objects.create(**status_data)
+        new_description = "Updated new description"
+
+        # WHEN
+        status.description = new_description
+        status.save()
+
+        # THEN
+        updated_status = Status.objects.get(pk=status.pk)
+        assert updated_status.description == new_description
+
+
+@pytest.mark.django_db
+class TestStatusDeletion:
+    """Tests for deletion of the Status model."""
+
+    def test_delete_status(self, status_data):
+        """
+        GIVEN: an existing Status
+        WHEN: deleting this Status
+        THEN: the Status no longer exists in the database
+        """
+        # GIVEN
+        status = Status.objects.create(**status_data)
+        status_id = status.pk
+
+        # WHEN
+        status.delete()
+
+        # THEN
+        assert not Status.objects.filter(pk=status_id).exists()

--- a/gardeniq/base/utils/tests.py
+++ b/gardeniq/base/utils/tests.py
@@ -23,6 +23,7 @@ class ViewSetTestMixin:
         obj() -> type[Model]:
             Returns a default model instance for use in tests.
     """
+
     BASE_PATTERN: str = ""
     MODEL: type[Model]
     DATA_TO_DEFAULT_OBJ: Dict

--- a/gardeniq/base/views/base.py
+++ b/gardeniq/base/views/base.py
@@ -4,11 +4,15 @@ from rest_framework.viewsets import ModelViewSet
 
 class BaseAPIModelViewSet(ModelViewSet):
     serializer_class: type[Serializer]
-    # Does read only serializer
+
+    # Does read only serializers
+    list_serializer_class: type[Serializer] | None = None
     detail_serializer_class: type[Serializer]
 
     def get_serializer_class(self):
-        if self.action == "retrieve":
+        if self.action == "list":
+            return self.list_serializer_class if self.list_serializer_class else self.detail_serializer_class
+        elif self.action == "retrieve":
             return self.detail_serializer_class
         else:
             return self.serializer_class

--- a/gardeniq/hardware/admin.py
+++ b/gardeniq/hardware/admin.py
@@ -1,3 +1,66 @@
-# from django.contrib import admin
+from typing import List
+
+from django.conf import settings
+from django.contrib import admin
+from django.forms import TypedChoiceField
+from django.http import HttpRequest
+
+from gardeniq.hardware.models import Device
+from gardeniq.hardware.utils import list_connected_devices
+
 
 # Register your models here.
+@admin.register(Device)
+class DeviceAdmin(admin.ModelAdmin):
+    """Admin interface for the Device model."""
+
+    list_display = (
+        "id",
+        "name",
+        "uid",
+        "path",
+        "status",
+        "last_seen",
+        "gd_firmware_version",
+        "mp_firmware_version",
+        "need_upgrade",
+    )
+    search_fields = ("name", "uid", "path")
+    list_filter = ("status", "need_upgrade", "gd_firmware_version", "mp_firmware_version")
+    fieldsets = (
+        (
+            "Device Information",
+            {
+                "fields": ("name", "description", "uid", "path"),
+            },
+        ),
+        (
+            "Firmware Information",
+            {
+                "fields": ("gd_firmware_version", "mp_firmware_version", "need_upgrade"),
+            },
+        ),
+        (
+            "Status Information",
+            {
+                "fields": ("status",),
+            },
+        ),
+    )
+
+    def _get_serial_port_choices(self) -> List[tuple[str, str]]:
+        serial_ports = list_connected_devices(settings.LD_FORMATS.LIST_DEVICES)
+        return [(p, p) for p in serial_ports]
+
+    def get_form(self, request: HttpRequest, obj=None, **kwargs):
+        """
+        Overrides the default form generation for the admin interface.
+
+        Retrieves the base form using the superclass implementation, then modifies the 'path' field
+        to be a TypedChoiceField with choices provided by `_get_serial_port_choices()` and coerced to string.
+        This allows dynamic selection of serial ports in the admin form.
+        """
+        # Get the base form
+        form = super().get_form(request, obj, **kwargs)
+        form.base_fields["path"] = TypedChoiceField(choices=self._get_serial_port_choices(), coerce=str)  # type: ignore
+        return form

--- a/gardeniq/hardware/models.py
+++ b/gardeniq/hardware/models.py
@@ -60,6 +60,10 @@ class Device(NameMixinModel, OptionalDescriptionMixinModel):
         help_text="Indicates if the device requires a firmware upgrade.",
     )
 
+    class Meta:
+        verbose_name = "device"
+        verbose_name_plural = "devices"
+
     def __str__(self) -> str:
         return f"Device `{self.name}` : {self.uid} : {self.path}"
 

--- a/gardeniq/hardware/protocols/errors.py
+++ b/gardeniq/hardware/protocols/errors.py
@@ -3,11 +3,13 @@ from gardeniq.base.utils import GardenEnum
 
 class FrameParsingError(Exception):
     """Raised when frame parsing fails."""
+
     pass
 
 
 class FrameProcessingError(Exception):
     """Raised when frame processing fails."""
+
     pass
 
 
@@ -26,6 +28,7 @@ class CommandError(GardenEnum):
         CHECKSUM_ERR: Data integrity check failed, indicating potential data corruption
         DEV_NOT_READY: Device is not in a state to accept or execute commands
     """
+
     UNKNOW_CMD = "UNKNOW_CMD"
     INVALID_PARAM = "INVALID_PARAM"
     TIMEOUT = "TIMEOUT"

--- a/gardeniq/hardware/protocols/frame.py
+++ b/gardeniq/hardware/protocols/frame.py
@@ -102,11 +102,7 @@ class Frame:
             bool: True if the calculated checksum matches the expected checksum,
                   False otherwise.
         """
-        if (
-            not self.from_device
-            or not self.source_frame_from_device
-            or not self.checksum
-        ):
+        if not self.from_device or not self.source_frame_from_device or not self.checksum:
             return False
 
         # explain int(checksum_part, 16):
@@ -124,19 +120,10 @@ class Frame:
         else:
             found_versions = False
 
-        return (
-            self.from_device
-            and self.frame_type is FrameType.ACK
-            and self.command_id == 0
-            and found_versions
-        )
+        return self.from_device and self.frame_type is FrameType.ACK and self.command_id == 0 and found_versions
 
     def _is_order_response(self) -> bool:
-        return (
-            self.from_device
-            and self.frame_type is FrameType.ACK
-            and self.command_id > 0
-        )
+        return self.from_device and self.frame_type is FrameType.ACK and self.command_id > 0
 
     def is_order_response_with_data(self) -> bool:
         return self._is_order_response() and self.ok_data is not None

--- a/gardeniq/orderlg/admin.py
+++ b/gardeniq/orderlg/admin.py
@@ -1,3 +1,54 @@
-# from django.contrib import admin
+from django.contrib import admin
+
+from gardeniq.orderlg.models import Argument
+from gardeniq.orderlg.models import Order
+
 
 # Register your models here.
+@admin.register(Argument)
+class ArgumentAdmin(admin.ModelAdmin):
+    """Admin interface for the Argument model."""
+
+    list_display = (
+        "id",
+        "slug",
+        "value_type",
+        "is_enabled",
+        "required",
+        "is_option",
+    )
+    search_fields = ("slug", "value_type")
+    list_filter = ("is_enabled", "required", "is_option", "orders")
+    # For ordering fields in admin create and update forms.
+    fields = (
+        "slug",
+        "description",
+        "value_type",
+        "required",
+        "is_option",
+        "is_enabled",
+    )
+
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    """Admin interface for the Order model."""
+
+    list_display = (
+        "id",
+        "name",
+        "slug",
+        "action_type",
+        "is_enabled",
+    )
+    search_fields = ("name", "slug", "action_type")
+    list_filter = ("action_type", "is_enabled", "arguments")
+    # For ordering fields in admin create and update forms.
+    fields = (
+        "name",
+        "slug",
+        "description",
+        "action_type",
+        "arguments",
+        "is_enabled",
+    )

--- a/gardeniq/orderlg/models/__init__.py
+++ b/gardeniq/orderlg/models/__init__.py
@@ -1,0 +1,2 @@
+from .argument import Argument
+from .order import Order

--- a/gardeniq/orderlg/models/argument.py
+++ b/gardeniq/orderlg/models/argument.py
@@ -43,5 +43,9 @@ class Argument(
         default=False, verbose_name="is option", help_text="A option is a argument without value like `--verbose`."
     )
 
+    class Meta:
+        verbose_name = "argument"
+        verbose_name_plural = "arguments"
+
     def __str__(self) -> str:
         return f"Argument `{self.slug}` {self.if_enabled()}"

--- a/gardeniq/orderlg/models/argument.py
+++ b/gardeniq/orderlg/models/argument.py
@@ -1,0 +1,47 @@
+from django.db import models
+
+from gardeniq.base.models import DescriptionMixinModel
+from gardeniq.base.models import ProtectedDeletedMixinModel
+from gardeniq.base.models import ProtectedDisabledMixinModel
+from gardeniq.base.models import SlugMixinModel
+
+
+class Argument(
+    DescriptionMixinModel,
+    SlugMixinModel,
+    ProtectedDisabledMixinModel,
+    ProtectedDeletedMixinModel,
+):
+    """
+    Inherited fields:
+      - `description`
+      - `slug`
+      - `is_enable`
+    """
+
+    VALUES_TYPE_CHOICES = (
+        ("int", "integer"),
+        ("float", "float"),
+        ("str", "string"),
+        ("bool", "boolean"),
+        ("list", "list"),
+        ("none", "none"),
+    )
+
+    value_type = models.CharField(
+        max_length=5,
+        choices=VALUES_TYPE_CHOICES,
+        verbose_name="value type",
+        help_text="A value type of a argument.",
+    )
+    required = models.BooleanField(
+        default=True,
+        verbose_name="required",
+        help_text="Define if this argument is required or not to the order.",
+    )
+    is_option = models.BooleanField(
+        default=False, verbose_name="is option", help_text="A option is a argument without value like `--verbose`."
+    )
+
+    def __str__(self) -> str:
+        return f"Argument `{self.slug}` {self.if_enabled()}"

--- a/gardeniq/orderlg/models/order.py
+++ b/gardeniq/orderlg/models/order.py
@@ -42,6 +42,10 @@ class Order(
         help_text="All the arguments necessary for the command to work.",
     )
 
+    class Meta:
+        verbose_name = "order"
+        verbose_name_plural = "orders"
+
     def __str__(self) -> str:
         return f"Order `{self.name}` {self.if_enabled()}"
 

--- a/gardeniq/orderlg/models/order.py
+++ b/gardeniq/orderlg/models/order.py
@@ -7,47 +7,7 @@ from gardeniq.base.models import NameMixinModel
 from gardeniq.base.models import ProtectedDeletedMixinModel
 from gardeniq.base.models import ProtectedDisabledMixinModel
 from gardeniq.base.models import SlugMixinModel
-
-
-class Argument(
-    DescriptionMixinModel,
-    SlugMixinModel,
-    ProtectedDisabledMixinModel,
-    ProtectedDeletedMixinModel,
-):
-    """
-    Inherited fields:
-      - `description`
-      - `slug`
-      - `is_enable`
-    """
-
-    VALUES_TYPE_CHOICES = (
-        ("int", "integer"),
-        ("float", "float"),
-        ("str", "string"),
-        ("bool", "boolean"),
-        ("list", "list"),
-        ("none", "none"),
-    )
-
-    value_type = models.CharField(
-        max_length=5,
-        choices=VALUES_TYPE_CHOICES,
-        verbose_name="value type",
-        help_text="A value type of a argument.",
-    )
-    required = models.BooleanField(
-        default=True,
-        verbose_name="required",
-        help_text="Define if this argument is required or not to the order.",
-    )
-    is_option = models.BooleanField(
-        default=False, verbose_name="is option", help_text="A option is a argument without value like `--verbose`."
-    )
-
-    def __str__(self) -> str:
-        return f"Argument `{self.slug}` {self.if_enabled()}"
+from gardeniq.orderlg.models import Argument
 
 
 class Order(

--- a/gardeniq/orderlg/serializers/__init__.py
+++ b/gardeniq/orderlg/serializers/__init__.py
@@ -1,4 +1,5 @@
 from .arguments import ArgumentReadOnlySerializer
 from .arguments import ArgumentSerializer
-from .arguments import OrderDetailReadOnlySerializer
-from .arguments import OrderSerializer
+from .order import OrderDetailReadOnlySerializer
+from .order import OrderListReadOnlySerializer
+from .order import OrderSerializer

--- a/gardeniq/orderlg/serializers/arguments.py
+++ b/gardeniq/orderlg/serializers/arguments.py
@@ -1,16 +1,11 @@
-from typing import Dict
-
 from rest_framework import serializers
 
-from gardeniq.base.serializers import AutocompleteSlugMixinSerializer
 from gardeniq.base.serializers import BaseSerializer
 from gardeniq.base.serializers import DescriptionMixinSerializer
 from gardeniq.base.serializers import EnabledMixinSerializer
-from gardeniq.base.serializers import NameMixinSerializer
 from gardeniq.base.serializers import ReadOnlySerializer
 from gardeniq.base.serializers import SimpleSlugMixinSerializer
 from gardeniq.orderlg.models import Argument
-from gardeniq.orderlg.models import Order
 
 
 class ArgumentSerializer(
@@ -41,39 +36,5 @@ class ArgumentReadOnlySerializer(ReadOnlySerializer, ArgumentSerializer):
     This serializer is intended for use cases where Argument data should be exposed
     in a read-only format, preventing any modifications through the API.
     """
+
     pass
-
-
-class OrderSerializer(
-    BaseSerializer,
-    NameMixinSerializer,
-    DescriptionMixinSerializer,
-    AutocompleteSlugMixinSerializer,
-    EnabledMixinSerializer,
-):
-    action_type = serializers.ChoiceField(choices=Order.ACTIONS_CHOICES)
-    arguments = serializers.PrimaryKeyRelatedField(
-        queryset=Argument.enabled.all(),
-        many=True,
-        required=False,
-    )
-
-    class Meta(BaseSerializer.Meta, AutocompleteSlugMixinSerializer.Meta):
-        model = Order
-        prepopulated_slug_with = "name"
-
-    def create(self, validated_data: Dict):
-        arguments = validated_data.pop("arguments")
-        new_order_obj = super().create(validated_data)
-        new_order_obj.arguments.set(arguments)  # pyright: ignore[reportAttributeAccessIssue]
-        return new_order_obj
-
-    def update(self, instance, validated_data: Dict):
-        arguments = validated_data.pop("arguments")
-        instance = super().update(instance, validated_data)
-        instance.arguments.set(arguments)
-        return instance
-
-
-class OrderDetailReadOnlySerializer(ReadOnlySerializer, OrderSerializer):
-    arguments = ArgumentSerializer(many=True, read_only=True)

--- a/gardeniq/orderlg/serializers/order.py
+++ b/gardeniq/orderlg/serializers/order.py
@@ -1,0 +1,60 @@
+from typing import Dict
+
+from rest_framework import serializers
+
+from gardeniq.base.serializers import AutocompleteSlugMixinSerializer
+from gardeniq.base.serializers import BaseSerializer
+from gardeniq.base.serializers import DescriptionMixinSerializer
+from gardeniq.base.serializers import EnabledMixinSerializer
+from gardeniq.base.serializers import NameMixinSerializer
+from gardeniq.base.serializers import ReadOnlySerializer
+from gardeniq.base.serializers import SimpleSlugMixinSerializer
+from gardeniq.base.serializers.mixins import PKMixinSerializer
+from gardeniq.orderlg.models import Argument
+from gardeniq.orderlg.models import Order
+from gardeniq.orderlg.serializers import ArgumentSerializer
+
+
+class OrderSerializer(
+    BaseSerializer,
+    NameMixinSerializer,
+    DescriptionMixinSerializer,
+    AutocompleteSlugMixinSerializer,
+    EnabledMixinSerializer,
+):
+    action_type = serializers.ChoiceField(choices=Order.ACTIONS_CHOICES)
+    arguments = serializers.PrimaryKeyRelatedField(
+        queryset=Argument.enabled.all(),
+        many=True,
+        required=False,
+    )
+
+    class Meta(BaseSerializer.Meta, AutocompleteSlugMixinSerializer.Meta):
+        model = Order
+        prepopulated_slug_with = "name"
+
+    def create(self, validated_data: Dict):
+        arguments = validated_data.pop("arguments")
+        new_order_obj = super().create(validated_data)
+        new_order_obj.arguments.set(arguments)  # pyright: ignore[reportAttributeAccessIssue]
+        return new_order_obj
+
+    def update(self, instance, validated_data: Dict):
+        arguments = validated_data.pop("arguments")
+        instance = super().update(instance, validated_data)
+        instance.arguments.set(arguments)
+        return instance
+
+
+class OrderListReadOnlySerializer(
+    ReadOnlySerializer,
+    PKMixinSerializer,
+    NameMixinSerializer,
+    SimpleSlugMixinSerializer,
+    EnabledMixinSerializer,
+):
+    action_type = serializers.CharField(read_only=True)
+
+
+class OrderDetailReadOnlySerializer(OrderListReadOnlySerializer, DescriptionMixinSerializer):
+    arguments = ArgumentSerializer(many=True, read_only=True)

--- a/gardeniq/orderlg/tests/tests_models/test_argument.py
+++ b/gardeniq/orderlg/tests/tests_models/test_argument.py
@@ -1,0 +1,404 @@
+import pytest
+
+from gardeniq.orderlg.models import Argument
+
+
+@pytest.fixture
+def argument_data():
+    """Fixture providing basic data to create an Argument."""
+    return {
+        "description": "Sensor ID to query",
+        "slug": "sensor-id",
+        "value_type": "int",
+        "required": True,
+        "is_option": False,
+    }
+
+
+@pytest.fixture
+def argument_with_defaults():
+    """Fixture providing minimal data relying on defaults."""
+    return {
+        "description": "Verbose mode",
+        "slug": "verbose",
+        "value_type": "bool",
+    }
+
+
+@pytest.fixture
+def argument_option():
+    """Fixture providing data for an option argument."""
+    return {
+        "description": "Debug mode",
+        "slug": "debug",
+        "value_type": "none",
+        "required": False,
+        "is_option": True,
+    }
+
+
+@pytest.mark.django_db
+class TestArgumentCreation:
+    """Tests for Argument model creation."""
+
+    def test_create_argument_with_all_fields(self, argument_data):
+        """
+        GIVEN: complete data for an Argument
+        WHEN: creating an Argument with all fields
+        THEN: the Argument is created with correct values
+        """
+        # GIVEN - data is provided by the argument_data fixture
+
+        # WHEN
+        argument = Argument.objects.create(**argument_data)
+
+        # THEN
+        assert argument.pk is not None
+        assert argument.description == argument_data["description"]
+        assert argument.slug == argument_data["slug"]
+        assert argument.value_type == argument_data["value_type"]
+        assert argument.required == argument_data["required"]
+        assert argument.is_option == argument_data["is_option"]
+        assert argument.is_enabled is True  # from ProtectedDisabledMixinModel
+
+    def test_create_argument_with_defaults(self, argument_with_defaults):
+        """
+        GIVEN: data without optional fields
+        WHEN: creating an Argument with minimal data
+        THEN: the Argument is created with default values
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        argument = Argument.objects.create(**argument_with_defaults)
+
+        # THEN
+        assert argument.pk is not None
+        assert argument.description == argument_with_defaults["description"]
+        assert argument.slug == argument_with_defaults["slug"]
+        assert argument.value_type == argument_with_defaults["value_type"]
+        assert argument.required is True  # default value
+        assert argument.is_option is False  # default value
+        assert argument.is_enabled is True
+
+    def test_create_argument_option(self, argument_option):
+        """
+        GIVEN: data for an option argument (without value)
+        WHEN: creating an Argument with is_option=True
+        THEN: the Argument is created as an option
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        argument = Argument.objects.create(**argument_option)
+
+        # THEN
+        assert argument.pk is not None
+        assert argument.is_option is True
+        assert argument.required is False
+        assert argument.value_type == "none"
+
+    def test_create_argument_with_each_value_type(self):
+        """
+        GIVEN: all available value types
+        WHEN: creating an Argument for each value type
+        THEN: each Argument is created with the correct value_type
+        """
+        # GIVEN
+        value_types = ["int", "float", "str", "bool", "list", "none"]
+
+        for value_type in value_types:
+            # WHEN
+            argument = Argument.objects.create(
+                description=f"Test {value_type}",
+                slug=f"test-{value_type}",
+                value_type=value_type,
+            )
+
+            # THEN
+            assert argument.value_type == value_type
+            assert argument.pk is not None
+
+
+@pytest.mark.django_db
+class TestArgumentStringRepresentation:
+    """Tests for Argument model string representation."""
+
+    def test_str_method_returns_correct_format_when_enabled(self, argument_data):
+        """
+        GIVEN: a created enabled Argument
+        WHEN: calling the __str__ method
+        THEN: it returns the format "Argument `{slug}` enabled"
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+
+        # WHEN
+        result = str(argument)
+
+        # THEN
+        expected = f"Argument `{argument_data['slug']}` enabled"
+        assert result == expected
+
+    def test_str_method_returns_correct_format_when_disabled(self, argument_data):
+        """
+        GIVEN: a created disabled Argument
+        WHEN: calling the __str__ method
+        THEN: it returns the format "Argument `{slug}` disabled"
+        """
+        # GIVEN
+        argument_data["is_enabled"] = False
+        argument = Argument.objects.create(**argument_data)
+
+        # WHEN
+        result = str(argument)
+
+        # THEN
+        expected = f"Argument `{argument_data['slug']}` disabled"
+        assert result == expected
+
+
+@pytest.mark.django_db
+class TestArgumentFields:
+    """Tests for Argument model fields and constraints."""
+
+    def test_description_field(self, argument_data):
+        """
+        GIVEN: a description for an Argument
+        WHEN: creating an Argument with this description
+        THEN: the Argument is created with the correct description
+        """
+        # GIVEN
+        long_description = "A" * 500
+
+        # WHEN
+        argument = Argument.objects.create(
+            description=long_description,
+            slug="test-long-description",
+            value_type="str",
+        )
+
+        # THEN
+        assert argument.description == long_description
+
+    def test_slug_field(self, argument_data):
+        """
+        GIVEN: a valid slug
+        WHEN: creating an Argument with this slug
+        THEN: the Argument is created with the correct slug
+        """
+        # GIVEN
+        slug = "sensor-temperature-external"
+
+        # WHEN
+        argument = Argument.objects.create(
+            description="External temperature sensor",
+            slug=slug,
+            value_type="float",
+        )
+
+        # THEN
+        assert argument.slug == slug
+
+    def test_required_field_default_is_true(self):
+        """
+        GIVEN: data without specifying required field
+        WHEN: creating an Argument
+        THEN: the required field defaults to True
+        """
+        # GIVEN / WHEN
+        argument = Argument.objects.create(
+            description="Test",
+            slug="test",
+            value_type="str",
+        )
+
+        # THEN
+        assert argument.required is True
+
+    def test_is_option_field_default_is_false(self):
+        """
+        GIVEN: data without specifying is_option field
+        WHEN: creating an Argument
+        THEN: the is_option field defaults to False
+        """
+        # GIVEN / WHEN
+        argument = Argument.objects.create(
+            description="Test",
+            slug="test",
+            value_type="str",
+        )
+
+        # THEN
+        assert argument.is_option is False
+
+    def test_is_enabled_field_default_is_true(self):
+        """
+        GIVEN: data without specifying is_enabled field
+        WHEN: creating an Argument
+        THEN: the is_enabled field defaults to True
+        """
+        # GIVEN / WHEN
+        argument = Argument.objects.create(
+            description="Test",
+            slug="test",
+            value_type="str",
+        )
+
+        # THEN
+        assert argument.is_enabled is True
+
+
+@pytest.mark.django_db
+class TestArgumentUpdate:
+    """Tests for Argument model update operations."""
+
+    def test_update_argument_description(self, argument_data):
+        """
+        GIVEN: an existing Argument
+        WHEN: updating its description
+        THEN: the description is modified correctly
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+        new_description = "Updated sensor ID description"
+
+        # WHEN
+        argument.description = new_description
+        argument.save()
+
+        # THEN
+        updated_argument = Argument.objects.get(pk=argument.pk)
+        assert updated_argument.description == new_description
+
+    def test_update_argument_value_type(self, argument_data):
+        """
+        GIVEN: an existing Argument
+        WHEN: updating its value_type
+        THEN: the value_type is modified correctly
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+        new_value_type = "str"
+
+        # WHEN
+        argument.value_type = new_value_type
+        argument.save()
+
+        # THEN
+        updated_argument = Argument.objects.get(pk=argument.pk)
+        assert updated_argument.value_type == new_value_type
+
+    def test_update_argument_required_status(self, argument_data):
+        """
+        GIVEN: an existing required Argument
+        WHEN: updating its required status to False
+        THEN: the required field is modified correctly
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+        assert argument.required is True
+
+        # WHEN
+        argument.required = False
+        argument.save()
+
+        # THEN
+        updated_argument = Argument.objects.get(pk=argument.pk)
+        assert updated_argument.required is False
+
+    def test_update_argument_enabled_status(self, argument_data):
+        """
+        GIVEN: an existing enabled Argument
+        WHEN: disabling the Argument
+        THEN: the is_enabled field is modified correctly
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+        assert argument.is_enabled is True
+
+        # WHEN
+        argument.is_enabled = False
+        argument.save()
+
+        # THEN
+        updated_argument = Argument.objects.get(pk=argument.pk)
+        assert updated_argument.is_enabled is False
+
+
+@pytest.mark.django_db
+class TestArgumentDeletion:
+    """Tests for deletion of the Argument model."""
+
+    def test_delete_argument(self, argument_data):
+        """
+        GIVEN: an existing Argument
+        WHEN: deleting this Argument
+        THEN: the Argument no longer exists in the database
+        """
+        # GIVEN
+        argument = Argument.objects.create(**argument_data)
+        argument_id = argument.pk
+
+        # WHEN
+        argument.delete()
+
+        # THEN
+        assert not Argument.objects.filter(pk=argument_id).exists()
+
+    def test_delete_multiple_arguments(self):
+        """
+        GIVEN: multiple existing Arguments
+        WHEN: deleting all Arguments
+        THEN: no Arguments exist in the database
+        """
+        # GIVEN
+        Argument.objects.create(description="Arg 1", slug="arg-1", value_type="int")
+        Argument.objects.create(description="Arg 2", slug="arg-2", value_type="str")
+        Argument.objects.create(description="Arg 3", slug="arg-3", value_type="bool")
+        assert Argument.objects.count() == 3
+
+        # WHEN
+        Argument.objects.all().delete()
+
+        # THEN
+        assert Argument.objects.count() == 0
+
+
+@pytest.mark.django_db
+class TestArgumentManager:
+    """Tests for Argument model custom manager (enabled)."""
+
+    def test_enabled_manager_returns_only_enabled_arguments(self):
+        """
+        GIVEN: multiple Arguments with different enabled statuses
+        WHEN: querying with the enabled manager
+        THEN: only enabled Arguments are returned
+        """
+        # GIVEN
+        enabled_arg1 = Argument.objects.create(
+            description="Enabled 1",
+            slug="enabled-1",
+            value_type="int",
+            is_enabled=True,
+        )
+        enabled_arg2 = Argument.objects.create(
+            description="Enabled 2",
+            slug="enabled-2",
+            value_type="str",
+            is_enabled=True,
+        )
+        Argument.objects.create(
+            description="Disabled",
+            slug="disabled",
+            value_type="bool",
+            is_enabled=False,
+        )
+
+        # WHEN
+        enabled_arguments = Argument.enabled.all()
+
+        # THEN
+        assert enabled_arguments.count() == 2
+        assert enabled_arg1 in enabled_arguments
+        assert enabled_arg2 in enabled_arguments

--- a/gardeniq/orderlg/tests/tests_models/test_order.py
+++ b/gardeniq/orderlg/tests/tests_models/test_order.py
@@ -1,0 +1,603 @@
+import pytest
+
+from gardeniq.orderlg.models import Argument
+from gardeniq.orderlg.models import Order
+
+
+@pytest.fixture
+def argument_sensor_id():
+    """Fixture providing an Argument for sensor ID."""
+    return Argument.objects.create(
+        description="Sensor ID to query",
+        slug="sensor-id",
+        value_type="int",
+        required=True,
+        is_option=False,
+    )
+
+
+@pytest.fixture
+def argument_verbose():
+    """Fixture providing an Argument for verbose mode."""
+    return Argument.objects.create(
+        description="Verbose mode",
+        slug="verbose",
+        value_type="bool",
+        required=False,
+        is_option=True,
+    )
+
+
+@pytest.fixture
+def argument_debug():
+    """Fixture providing an Argument for debug mode."""
+    return Argument.objects.create(
+        description="Debug mode",
+        slug="debug",
+        value_type="bool",
+        required=False,
+        is_option=True,
+    )
+
+
+@pytest.fixture
+def order_data():
+    """Fixture providing basic data to create an Order."""
+    return {
+        "name": "Get Temperature",
+        "description": "Retrieve temperature from sensor",
+        "slug": "get-temperature",
+        "action_type": "get",
+    }
+
+
+@pytest.fixture
+def order_setter_data():
+    """Fixture providing data for a setter Order."""
+    return {
+        "name": "Set LED State",
+        "description": "Set the state of the LED",
+        "slug": "set-led-state",
+        "action_type": "set",
+    }
+
+
+@pytest.fixture
+def order_minimal_data():
+    """Fixture providing minimal data relying on defaults."""
+    return {
+        "name": "Check Status",
+        "action_type": "get",
+    }
+
+
+@pytest.mark.django_db
+class TestOrderCreation:
+    """Tests for Order model creation."""
+
+    def test_create_order_with_all_fields(self, order_data):
+        """
+        GIVEN: complete data for an Order
+        WHEN: creating an Order with all fields
+        THEN: the Order is created with correct values
+        """
+        # GIVEN - data is provided by the order_data fixture
+
+        # WHEN
+        order = Order.objects.create(**order_data)
+
+        # THEN
+        assert order.pk is not None
+        assert order.name == order_data["name"]
+        assert order.description == order_data["description"]
+        assert order.slug == order_data["slug"]
+        assert order.action_type == order_data["action_type"]
+        assert order.is_enabled is True  # from ProtectedDisabledMixinModel
+
+    def test_create_order_with_minimal_data(self, order_minimal_data):
+        """
+        GIVEN: minimal data for an Order
+        WHEN: creating an Order with minimal data
+        THEN: the Order is created with default values
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        order = Order.objects.create(**order_minimal_data)
+
+        # THEN
+        assert order.pk is not None
+        assert order.name == order_minimal_data["name"]
+        assert order.action_type == order_minimal_data["action_type"]
+        assert order.is_enabled is True
+
+    def test_create_order_with_getter_action(self, order_data):
+        """
+        GIVEN: data for a getter Order
+        WHEN: creating an Order with action_type='get'
+        THEN: the Order is created as a getter
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        order = Order.objects.create(**order_data)
+
+        # THEN
+        assert order.pk is not None
+        assert order.action_type == "get"
+
+    def test_create_order_with_setter_action(self, order_setter_data):
+        """
+        GIVEN: data for a setter Order
+        WHEN: creating an Order with action_type='set'
+        THEN: the Order is created as a setter
+        """
+        # GIVEN - data is provided by the fixture
+
+        # WHEN
+        order = Order.objects.create(**order_setter_data)
+
+        # THEN
+        assert order.pk is not None
+        assert order.action_type == "set"
+
+    def test_create_order_with_arguments(self, order_data, argument_sensor_id, argument_verbose):
+        """
+        GIVEN: an Order and multiple Arguments
+        WHEN: creating an Order and adding Arguments to it
+        THEN: the Order is created with the correct Arguments
+        """
+        # GIVEN - fixtures provide the data and arguments
+
+        # WHEN
+        order = Order.objects.create(**order_data)
+        order.arguments.add(argument_sensor_id, argument_verbose)
+
+        # THEN
+        assert order.arguments.count() == 2
+        assert argument_sensor_id in order.arguments.all()
+        assert argument_verbose in order.arguments.all()
+
+
+@pytest.mark.django_db
+class TestOrderStringRepresentation:
+    """Tests for Order model string representation."""
+
+    def test_str_method_returns_correct_format_when_enabled(self, order_data):
+        """
+        GIVEN: a created enabled Order
+        WHEN: calling the __str__ method
+        THEN: it returns the format "Order `{name}` enabled"
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+
+        # WHEN
+        result = str(order)
+
+        # THEN
+        expected = f"Order `{order_data['name']}` enabled"
+        assert result == expected
+
+    def test_str_method_returns_correct_format_when_disabled(self, order_data):
+        """
+        GIVEN: a created disabled Order
+        WHEN: calling the __str__ method
+        THEN: it returns the format "Order `{name}` disabled"
+        """
+        # GIVEN
+        order_data["is_enabled"] = False
+        order = Order.objects.create(**order_data)
+
+        # WHEN
+        result = str(order)
+
+        # THEN
+        expected = f"Order `{order_data['name']}` disabled"
+        assert result == expected
+
+
+@pytest.mark.django_db
+class TestOrderFields:
+    """Tests for Order model fields and constraints."""
+
+    def test_name_field(self, order_data):
+        """
+        GIVEN: a name for an Order
+        WHEN: creating an Order with this name
+        THEN: the Order is created with the correct name
+        """
+        # GIVEN
+        name = "Get Sensor Data"
+
+        # WHEN
+        order = Order.objects.create(
+            name=name,
+            action_type="get",
+        )
+
+        # THEN
+        assert order.name == name
+
+    def test_description_field(self, order_data):
+        """
+        GIVEN: a description for an Order
+        WHEN: creating an Order with this description
+        THEN: the Order is created with the correct description
+        """
+        # GIVEN
+        long_description = "A" * 500
+
+        # WHEN
+        order = Order.objects.create(
+            name="Test Order",
+            description=long_description,
+            action_type="get",
+        )
+
+        # THEN
+        assert order.description == long_description
+
+    def test_slug_field(self, order_data):
+        """
+        GIVEN: a valid slug
+        WHEN: creating an Order with this slug
+        THEN: the Order is created with the correct slug
+        """
+        # GIVEN
+        slug = "get-temperature-sensor-external"
+
+        # WHEN
+        order = Order.objects.create(
+            name="Get Temperature Sensor External",
+            slug=slug,
+            action_type="get",
+        )
+
+        # THEN
+        assert order.slug == slug
+
+    def test_action_type_field_getter(self):
+        """
+        GIVEN: action_type='get'
+        WHEN: creating an Order with getter action
+        THEN: the action_type field is set to 'get'
+        """
+        # GIVEN / WHEN
+        order = Order.objects.create(
+            name="Getter Order",
+            action_type="get",
+        )
+
+        # THEN
+        assert order.action_type == "get"
+
+    def test_action_type_field_setter(self):
+        """
+        GIVEN: action_type='set'
+        WHEN: creating an Order with setter action
+        THEN: the action_type field is set to 'set'
+        """
+        # GIVEN / WHEN
+        order = Order.objects.create(
+            name="Setter Order",
+            action_type="set",
+        )
+
+        # THEN
+        assert order.action_type == "set"
+
+    def test_is_enabled_field_default_is_true(self):
+        """
+        GIVEN: data without specifying is_enabled field
+        WHEN: creating an Order
+        THEN: the is_enabled field defaults to True
+        """
+        # GIVEN / WHEN
+        order = Order.objects.create(
+            name="Test Order",
+            action_type="get",
+        )
+
+        # THEN
+        assert order.is_enabled is True
+
+
+@pytest.mark.django_db
+class TestOrderUpdate:
+    """Tests for Order model update operations."""
+
+    def test_update_order_name(self, order_data):
+        """
+        GIVEN: an existing Order
+        WHEN: updating its name
+        THEN: the name is modified correctly
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        new_name = "Updated Order Name"
+
+        # WHEN
+        order.name = new_name
+        order.save()
+
+        # THEN
+        updated_order = Order.objects.get(pk=order.pk)
+        assert updated_order.name == new_name
+
+    def test_update_order_description(self, order_data):
+        """
+        GIVEN: an existing Order
+        WHEN: updating its description
+        THEN: the description is modified correctly
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        new_description = "Updated description"
+
+        # WHEN
+        order.description = new_description
+        order.save()
+
+        # THEN
+        updated_order = Order.objects.get(pk=order.pk)
+        assert updated_order.description == new_description
+
+    def test_update_order_action_type(self, order_data):
+        """
+        GIVEN: an existing Order with action_type='get'
+        WHEN: updating its action_type to 'set'
+        THEN: the action_type is modified correctly
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        assert order.action_type == "get"
+
+        # WHEN
+        order.action_type = "set"
+        order.save()
+
+        # THEN
+        updated_order = Order.objects.get(pk=order.pk)
+        assert updated_order.action_type == "set"
+
+    def test_update_order_enabled_status(self, order_data):
+        """
+        GIVEN: an existing enabled Order
+        WHEN: disabling the Order
+        THEN: the is_enabled field is modified correctly
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        assert order.is_enabled is True
+
+        # WHEN
+        order.is_enabled = False
+        order.save()
+
+        # THEN
+        updated_order = Order.objects.get(pk=order.pk)
+        assert updated_order.is_enabled is False
+
+
+@pytest.mark.django_db
+class TestOrderDeletion:
+    """Tests for deletion of the Order model."""
+
+    def test_delete_order(self, order_data):
+        """
+        GIVEN: an existing Order
+        WHEN: deleting this Order
+        THEN: the Order no longer exists in the database
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        order_id = order.pk
+
+        # WHEN
+        order.delete()
+
+        # THEN
+        assert not Order.objects.filter(pk=order_id).exists()
+
+    def test_delete_multiple_orders(self):
+        """
+        GIVEN: multiple existing Orders
+        WHEN: deleting all Orders
+        THEN: no Orders exist in the database
+        """
+        # GIVEN
+        Order.objects.create(name="Order 1", action_type="get")
+        Order.objects.create(name="Order 2", action_type="set")
+        Order.objects.create(name="Order 3", action_type="get")
+        assert Order.objects.count() == 3
+
+        # WHEN
+        Order.objects.all().delete()
+
+        # THEN
+        assert Order.objects.count() == 0
+
+
+@pytest.mark.django_db
+class TestOrderManager:
+    """Tests for Order model custom manager (enabled)."""
+
+    def test_enabled_manager_returns_only_enabled_orders(self):
+        """
+        GIVEN: multiple Orders with different enabled statuses
+        WHEN: querying with the enabled manager
+        THEN: only enabled Orders are returned
+        """
+        # GIVEN
+        enabled_order1 = Order.objects.create(
+            name="Enabled 1",
+            action_type="get",
+            is_enabled=True,
+        )
+        enabled_order2 = Order.objects.create(
+            name="Enabled 2",
+            action_type="set",
+            is_enabled=True,
+        )
+        Order.objects.create(
+            name="Disabled",
+            action_type="get",
+            is_enabled=False,
+        )
+
+        # WHEN
+        enabled_orders = Order.enabled.all()
+
+        # THEN
+        assert enabled_orders.count() == 2
+        assert enabled_order1 in enabled_orders
+        assert enabled_order2 in enabled_orders
+
+
+@pytest.mark.django_db
+class TestOrderArgumentsRelationship:
+    """Tests for Order and Argument ManyToMany relationship."""
+
+    def test_add_single_argument_to_order(self, order_data, argument_sensor_id):
+        """
+        GIVEN: an Order and an Argument
+        WHEN: adding the Argument to the Order
+        THEN: the Order has the Argument in its arguments
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+
+        # WHEN
+        order.arguments.add(argument_sensor_id)
+
+        # THEN
+        assert order.arguments.count() == 1
+        assert argument_sensor_id in order.arguments.all()
+
+    def test_add_multiple_arguments_to_order(self, order_data, argument_sensor_id, argument_verbose, argument_debug):
+        """
+        GIVEN: an Order and multiple Arguments
+        WHEN: adding multiple Arguments to the Order
+        THEN: the Order has all Arguments in its arguments
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+
+        # WHEN
+        order.arguments.add(argument_sensor_id, argument_verbose, argument_debug)
+
+        # THEN
+        assert order.arguments.count() == 3
+        assert argument_sensor_id in order.arguments.all()
+        assert argument_verbose in order.arguments.all()
+        assert argument_debug in order.arguments.all()
+
+    def test_remove_argument_from_order(self, order_data, argument_sensor_id, argument_verbose):
+        """
+        GIVEN: an Order with multiple Arguments
+        WHEN: removing one Argument from the Order
+        THEN: the Order no longer has the removed Argument
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        order.arguments.add(argument_sensor_id, argument_verbose)
+        assert order.arguments.count() == 2
+
+        # WHEN
+        order.arguments.remove(argument_sensor_id)
+
+        # THEN
+        assert order.arguments.count() == 1
+        assert argument_sensor_id not in order.arguments.all()
+        assert argument_verbose in order.arguments.all()
+
+    def test_clear_all_arguments_from_order(self, order_data, argument_sensor_id, argument_verbose):
+        """
+        GIVEN: an Order with multiple Arguments
+        WHEN: clearing all Arguments from the Order
+        THEN: the Order has no Arguments
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        order.arguments.add(argument_sensor_id, argument_verbose)
+        assert order.arguments.count() == 2
+
+        # WHEN
+        order.arguments.clear()
+
+        # THEN
+        assert order.arguments.count() == 0
+
+    def test_argument_can_belong_to_multiple_orders(self, order_data, order_setter_data, argument_sensor_id):
+        """
+        GIVEN: multiple Orders and one Argument
+        WHEN: adding the same Argument to multiple Orders
+        THEN: the Argument belongs to all Orders
+        """
+        # GIVEN
+        order1 = Order.objects.create(**order_data)
+        order2 = Order.objects.create(**order_setter_data)
+
+        # WHEN
+        order1.arguments.add(argument_sensor_id)
+        order2.arguments.add(argument_sensor_id)
+
+        # THEN
+        assert argument_sensor_id in order1.arguments.all()
+        assert argument_sensor_id in order2.arguments.all()
+        assert argument_sensor_id.orders.count() == 2
+
+    def test_deleting_argument_removes_from_order(self, order_data, argument_sensor_id):
+        """
+        GIVEN: an Order with an Argument
+        WHEN: deleting the Argument
+        THEN: the Order no longer has the Argument
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+        order.arguments.add(argument_sensor_id)
+        assert order.arguments.count() == 1
+
+        # WHEN
+        argument_sensor_id.delete()
+
+        # THEN
+        assert order.arguments.count() == 0
+
+
+@pytest.mark.django_db
+class TestOrderPrepopulatedSlug:
+    """Tests for Order prepopulated_slug method."""
+
+    def test_prepopulated_slug_returns_name(self, order_data):
+        """
+        GIVEN: an Order with a name
+        WHEN: calling the prepopulated_slug method
+        THEN: it returns the Order's name
+        """
+        # GIVEN
+        order = Order.objects.create(**order_data)
+
+        # WHEN
+        result = order.prepopulated_slug()
+
+        # THEN
+        assert result == order.name
+
+    def test_prepopulated_slug_with_different_names(self):
+        """
+        GIVEN: multiple Orders with different names
+        WHEN: calling prepopulated_slug on each
+        THEN: each returns its respective name
+        """
+        # GIVEN
+        names = ["Order One", "Order Two", "Order Three"]
+
+        for name in names:
+            # WHEN
+            order = Order.objects.create(name=name, action_type="get")
+            result = order.prepopulated_slug()
+
+            # THEN
+            assert result == name

--- a/gardeniq/orderlg/tests/tests_serializers/test_order.py
+++ b/gardeniq/orderlg/tests/tests_serializers/test_order.py
@@ -3,6 +3,7 @@ import pytest
 from gardeniq.orderlg.models import Argument
 from gardeniq.orderlg.models import Order
 from gardeniq.orderlg.serializers import OrderDetailReadOnlySerializer
+from gardeniq.orderlg.serializers import OrderListReadOnlySerializer
 from gardeniq.orderlg.serializers import OrderSerializer
 
 
@@ -139,6 +140,105 @@ class TestOrderSerializer:
         assert order.description == updated_data["description"]
         assert order.action_type == updated_data["action_type"]
         assert order.arguments.count() == 2
+
+
+@pytest.mark.django_db
+class TestOrderListReadOnlySerializer:
+    def test_cannot_create_order_serializer(self):
+        # GIVEN
+        order_count_before = Order.objects.count()
+        data = {
+            "name": "Test Order",
+            "action_type": "get",
+        }
+
+        # WHEN
+        serializer = OrderListReadOnlySerializer(data=data)
+        assert serializer.is_valid()
+        with pytest.raises(NotImplementedError):
+            serializer.save()
+
+        order_count_after = Order.objects.count()
+
+        # THEN
+        assert order_count_before == order_count_after
+
+    def test_cannot_update_order_serializer(self, create_order):
+        # GIVEN
+        order = create_order
+        data = {
+            "name": "Test Update Order",
+            "action_type": "set",
+        }
+
+        # WHEN
+        serializer = OrderListReadOnlySerializer(instance=order, data=data)
+        assert serializer.is_valid()
+        with pytest.raises(NotImplementedError):
+            serializer.save()
+
+        order_after_trying_update = Order.objects.get(pk=order.pk)
+
+        # THEN
+        assert order_after_trying_update.name != data["name"]
+        assert order_after_trying_update.name == order.name
+
+    def test_list_serializer(self, create_order):
+        # GIVEN
+        order = create_order
+        expected = {
+            "id": order.pk,
+            "name": order.name,
+            "slug": order.slug,
+            "action_type": order.action_type,
+            "is_enabled": order.is_enabled,
+        }
+
+        # WHEN
+        serializer = OrderListReadOnlySerializer(instance=order)
+
+        # THEN
+        assert serializer.data == expected
+
+    def test_list_serializer_multiple_orders(self, create_arguments):
+        # GIVEN
+        arg1, arg2 = create_arguments
+        order1 = Order.objects.create(
+            name="First Order",
+            description="First Description",
+            action_type="get",
+        )
+        order1.arguments.set([arg1])
+
+        order2 = Order.objects.create(
+            name="Second Order",
+            description="Second Description",
+            action_type="set",
+        )
+        order2.arguments.set([arg2])
+
+        expected = [
+            {
+                "id": order1.pk,
+                "name": order1.name,
+                "slug": order1.slug,
+                "action_type": order1.action_type,
+                "is_enabled": order1.is_enabled,
+            },
+            {
+                "id": order2.pk,
+                "name": order2.name,
+                "slug": order2.slug,
+                "action_type": order2.action_type,
+                "is_enabled": order2.is_enabled,
+            },
+        ]
+
+        # WHEN
+        serializer = OrderListReadOnlySerializer(instance=[order1, order2], many=True)
+
+        # THEN
+        assert serializer.data == expected
 
 
 @pytest.mark.django_db

--- a/gardeniq/orderlg/tests/tests_views/test_orders.py
+++ b/gardeniq/orderlg/tests/tests_views/test_orders.py
@@ -67,10 +67,8 @@ class TestOrderAPIModelView(OrderViewSetTestConf):
         # Check response data format
         first_order = response.data["results"][0]
         assert "name" in first_order
-        assert "description" in first_order
         assert "action_type" in first_order
         assert "is_enabled" in first_order
-        assert "arguments" in first_order
 
     def test_retrieve(self, client_anonymous, obj):
         """Test retrieving a specific order."""

--- a/gardeniq/orderlg/views.py
+++ b/gardeniq/orderlg/views.py
@@ -5,6 +5,7 @@ from gardeniq.orderlg.models import Order
 from gardeniq.orderlg.serializers import ArgumentReadOnlySerializer
 from gardeniq.orderlg.serializers import ArgumentSerializer
 from gardeniq.orderlg.serializers import OrderDetailReadOnlySerializer
+from gardeniq.orderlg.serializers import OrderListReadOnlySerializer
 from gardeniq.orderlg.serializers import OrderSerializer
 
 
@@ -16,6 +17,7 @@ class ArgumentAPIModelView(DisableAPIViewMixin, BaseAPIModelViewSet):
 
 class OrderAPIModelView(DisableAPIViewMixin, BaseAPIModelViewSet):
     serializer_class = OrderSerializer
+    list_serializer_class = OrderListReadOnlySerializer
     detail_serializer_class = OrderDetailReadOnlySerializer
     queryset = Order.objects.all()
 


### PR DESCRIPTION
# 📋 Résumé de la Pull Request - Refactoring du Code

## 🎯 Objectif Principal
Refactorisation complète du code incluant améliorations de formatage, restructuration des modèles, et ajout de tests complets.

---

## 📝 Changements Détaillés

### 🔧 Configuration et Outils de Développement

#### CI/CD Pipeline (`.github/workflows/ci.yml`)
- ✅ **Ajout de Black check** : Nouveau contrôle de formatage du code avec Black avant les autres vérifications
- 🔄 **Renumérotation des étapes** : Les numéros des étapes suivantes ont été ajustés pour refléter l'ajout du contrôle Black

#### Pre-commit Hooks (`.pre-commit-config.yaml`)
- 🔄 **Modification des arguments isort** : Réorganisation pour exclure les répertoires de migrations de manière plus explicite

---

### 📦 Module `base` - Améliorations et Tests

#### Admin Interface (`gardeniq/base/admin.py`)
- 🆕 **Activation du modèle Status** : Enregistrement complet du modèle Status dans l'interface admin Django
- 📋 Affichage des colonnes : `id`, `name`, `tag`, `color`, `description`
- 🔍 Recherche par : `name`, `tag`
- 🏷️ Filtrage par : `color`

#### Modèle Status (`gardeniq/base/models/status.py`)
- ✨ **Ajout de Meta class** : Définition des noms singulier/pluriel (`status`/`statuses`)
- 🎨 Amélioration de la structure et de la lisibilité

#### Serializers (`gardeniq/base/serializers/`)
- 🔤 **Formatage Black** : Application des règles de formatage Black
- 📏 **Amélioration de la lisibilité** : Réorganisation des assertions et messages d'erreur
- ✅ Regex pour validation des couleurs hexadécimales mieux formatée

#### Views (`gardeniq/base/views/base.py`)
- 🆕 **Propriété list_serializer_class** : Support pour un serializer distinct pour les listes
- 🔄 **Logique get_serializer_class améliorée** :
  - Retourne `list_serializer_class` pour l'action `list`
  - Retourne `detail_serializer_class` pour l'action `retrieve`
  - Retourne `serializer_class` par défaut pour les autres actions

#### Tests Complets (`gardeniq/base/tests/tests_models/test_status.py`) - 🆕 **NOUVEAU**
- ✅ Tests de création du modèle Status (avec tous les champs, sans description, avec couleur par défaut)
- ✅ Tests de représentation string
- ✅ Tests des contraintes de champs (longueur max, type de données)
- ✅ Tests de mise à jour
- ✅ Tests de suppression
- **Total** : 251 lignes de tests

---

### 💾 Module `hardware` - Admin et Models

#### Admin Interface (`gardeniq/hardware/admin.py`)
- 🆕 **Implémentation complète du DeviceAdmin**
- 📋 Affichage détaillé : `id`, `name`, `uid`, `path`, `status`, `last_seen`, versions firmware, etc.
- 🔍 Recherche multi-champs
- 📊 Regroupement des champs en fieldsets (Device Info, Firmware Info, Status Info)
- 🔌 **Sélecteur dynamique de ports série** : Utilise `list_connected_devices()` pour afficher les ports disponibles

#### Modèle Device (`gardeniq/hardware/models.py`)
- ✨ **Ajout de Meta class** : Définition des noms singulier/pluriel (`device`/`devices`)

#### Protocols (`gardeniq/hardware/protocols/`)
- 🔤 **Formatage Black** : Amélioration des règles d'espacement
- 🎯 Simplification des conditions logiques pour meilleure lisibilité
- ✨ Amélioration générale du code

---

### 📦 Module `orderlg` - Restructuration Majeure

#### Restructuration des Modèles
- 🔄 **Séparation des fichiers** :
  - `models.py` → `models/argument.py` + `models/order.py`
  - Importation unifiée via `models/__init__.py`
- ✨ Ajout de Meta class pour les modèles `Argument`, `Order`

#### Admin Interface (`gardeniq/orderlg/admin.py`)
- 🆕 **Implémentation ArgumentAdmin**
  - 📋 Affichage : `id`, `slug`, `value_type`, `is_enabled`, `required`, `is_option`
  - 🔍 Recherche par : `slug`, `value_type`
  - 📊 Filtrage par : `is_enabled`, `required`, `is_option`, `orders`

- 🆕 **Implémentation OrderAdmin**
  - 📋 Affichage : `id`, `name`, `slug`, `action_type`, `is_enabled`
  - 🔍 Recherche par : `name`, `slug`, `action_type`
  - 📊 Filtrage par : `action_type`, `is_enabled`, `arguments`

#### Serializers (`gardeniq/orderlg/serializers/`)
- 🔄 **Réorganisation** :
  - `arguments.py` : Contient uniquement les serializers pour Argument
  - `order.py` : Nouveaux serializers pour Order (créé)
- 🆕 **Nouveau OrderListReadOnlySerializer** :
  - Serializer allégé pour les listes
  - Inclut : `id`, `name`, `slug`, `action_type`, `is_enabled`
  - N'inclut pas : `description`, `arguments`

#### Tests Complets
- **test_argument.py** - 🆕 **NOUVEAU** (404 lignes)
  - ✅ Tests de création avec tous les types de valeurs
  - ✅ Tests de représentation string
  - ✅ Tests des contraintes de champs
  - ✅ Tests de mise à jour
  - ✅ Tests de suppression
  - ✅ Tests du manager `enabled`

- **test_order.py** - 🆕 **NOUVEAU** (603 lignes)
  - ✅ Tests de création (getter, setter, avec arguments)
  - ✅ Tests de représentation string
  - ✅ Tests des champs et contraintes
  - ✅ Tests de mise à jour et suppression
  - ✅ Tests de la relation ManyToMany avec Arguments
  - ✅ Tests du manager `enabled`
  - ✅ Tests de la méthode `prepopulated_slug()`

#### Views (`gardeniq/orderlg/views.py`)
- 🔄 **Utilisation du nouveau serializer** :
  - `OrderAPIModelView` utilise maintenant `list_serializer_class = OrderListReadOnlySerializer`
  - Les listes affichent les données allégées

#### Tests de Views (`gardeniq/orderlg/tests/tests_views/test_orders.py`)
- 🔄 **Mise à jour des assertions** :
  - Suppression des assertions pour `description` et `arguments` dans les tests de liste
  - Alignement avec le nouveau `OrderListReadOnlySerializer`

---

## 📊 Statistiques de la PR

| Catégorie | Impact |
|-----------|--------|
| 🔤 **Formatage Black** | Fichiers affectés : 12+ |
| 🆕 **Nouveaux fichiers** | 11 fichiers |
| 🏗️ **Restructuration** | Modèles `orderlg` réorganisés |
| ✅ **Tests ajoutés** | ~1 300+ lignes de tests |
| 🎨 **Admin interfaces** | 4 modèles enregistrés |
| 📈 **Couverture** | Amélioration significative |

---

## ✨ Bénéfices

- ✅ Code plus cohérent et formaté selon les standards (Black)
- ✅ Structure de projet améliorée avec séparation claire des modèles
- ✅ Interface admin complète et fonctionnelle pour tous les modèles
- ✅ Tests exhaustifs pour assurer la qualité du code
- ✅ API plus optimisée avec des serializers adaptés par action
- ✅ Meilleure maintenabilité et lisibilité du code
- 🔍 Meilleur support pour les développeurs via l'interface admin

---

## 🎯 Branche Source
- **Branche** : `(TK-47)(enh)code-refacto`
- **Cible** : `main`
